### PR TITLE
Added 'resource' claim to JWT grant to populate 'aud' claim in access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To generate a jwt-grant you need a propery file holding your client configuratio
 ```
 issuer=<Your client_id>
 audience=<Identifier of the idporten-oidc-provider instance you want to use, i.e. for ver2 env:  https://oidc-ver2.difi.no/idporten-oidc-provider/>
+resource=<The intended audience for token. If included, the value will be transparantly set as the aud-claim in the access token>
 scope=<scopes to request access for (space delimited list), i.e. for id-porten self service api use: idporten:dcr.read idporten:dcr.write>
 
 keystore.file=<path to your keystore file holding your virksomhetssertifikat / keypair>

--- a/example-client.properties
+++ b/example-client.properties
@@ -1,5 +1,6 @@
 issuer=<your client_id>
 audience=https://oidc-ver2.difi.no/idporten-oidc-provider/
+resource=<your intended audience>
 token.endpoint=https://oidc-ver2.difi.no/idporten-oidc-provider/token
 scope=idporten:dcr.read idporten:dcr.write
 

--- a/src/main/java/no/difi/oauth2/utils/Configuration.java
+++ b/src/main/java/no/difi/oauth2/utils/Configuration.java
@@ -13,6 +13,7 @@ public class Configuration {
 
     private String iss;
     private String aud;
+    private String resource;
     private String scope;
     private String tokenEndpoint;
     private X509Certificate certificate;
@@ -33,6 +34,14 @@ public class Configuration {
 
     public void setAud(String aud) {
         this.aud = aud;
+    }
+
+    public String getResource() {
+	return resource;
+    }
+
+    public void setResource(String resource) {
+	this.resource = resource;
     }
 
     public X509Certificate getCertificate() {
@@ -80,6 +89,7 @@ public class Configuration {
 
             config.setIss(props.getProperty("issuer"));
             config.setAud(props.getProperty("audience"));
+            config.setResource(props.getProperty("resource"));
             config.setScope(props.getProperty("scope"));
             config.setTokenEndpoint(props.getProperty("token.endpoint"));
 
@@ -129,3 +139,4 @@ public class Configuration {
     }
 
 }
+

--- a/src/main/java/no/difi/oauth2/utils/JwtGrantGenerator.java
+++ b/src/main/java/no/difi/oauth2/utils/JwtGrantGenerator.java
@@ -43,6 +43,7 @@ public class JwtGrantGenerator {
 
         JWTClaimsSet claims = new JWTClaimsSet.Builder()
                 .audience(config.getAud())
+                .claim("resource", config.getResource())
                 .issuer(config.getIss())
                 .claim("scope", config.getScope())
                 .jwtID(UUID.randomUUID().toString()) // Must be unique for each grant


### PR DESCRIPTION
This allows configuring the indended audience for token. If included, the value will be transparantly set as the aud-claim in the access token, per https://difi.github.io/felleslosninger/oidc_protocol_jwtgrant.html