### PR TITLE
Consumer org claim and json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,27 @@ mvn package
 java -jar target\jwt-grant-generator-1.0-SNAPSHOT-jar-with-dependencies.jar myclient.properties
 
 ```
+
+### Output as JSON
+If you want the response as json, you can add an additional parameter so the command to build and run is
+```
+mvn package
+
+java -jar target\jwt-grant-generator-1.0-SNAPSHOT-jar-with-dependencies.jar myclient.properties java
+
+```
+
+The JSON will be a single line so it is easy to capture in a script and can then be parsed with tools like jq.
+A pretty representation of the JSON schema is
+```
+{
+    "grant": "...",
+    "token": {
+        "access_token": "...",
+        "token_type": "Bearer",
+        "expires_in": 7199,
+        "scope": "..."
+    }
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is important to understand the authorization flow used for these apis, see ht
 Note: The access token is only retrieved if an token.endpoint property is given. Without this a jwt bearer grant will only be printed.
 
 ### Client configuration
-To generate a jwt-grant you need a propery file holding your client configuration:
+To generate a jwt-grant you need a property file holding your client configuration:
 
 ```
 issuer=<Your client_id>
@@ -28,6 +28,11 @@ To also retrieve an access-token from an authorization server, add this property
 
 ```
 token.endpoint=<Token endpoint to use, i.e. in ver2 env: https://oidc-ver2.difi.no/idporten-oidc-provider/token>
+```
+
+If you want to generate a token utilising the delegation capabilities in Maskinporten, add this property to the properties file:
+```
+consumer_org=<the orgnumer of the consumner that has delegated the access>
 ```
 
 ## Usage

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,13 @@
 			<artifactId>slf4j-nop</artifactId>
 			<version>1.7.25</version>
 		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.0</version>
+        </dependency>
 	</dependencies>
-    
+
 	<build>
         <plugins>
             <plugin>

--- a/src/main/java/no/difi/oauth2/utils/Configuration.java
+++ b/src/main/java/no/difi/oauth2/utils/Configuration.java
@@ -1,6 +1,5 @@
 package no.difi.oauth2.utils;
 
-
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -18,7 +17,8 @@ public class Configuration {
     private String tokenEndpoint;
     private X509Certificate certificate;
     private PrivateKey privateKey;
-
+    private String consumerOrg;
+    private Boolean jsonOutput = false;
 
     public String getIss() {
         return iss;
@@ -41,7 +41,23 @@ public class Configuration {
     }
 
     public void setResource(String resource) {
-	this.resource = resource;
+        this.resource = resource;
+    }
+
+    public void setConsumerOrg(String consumerOrg) {
+	this.consumerOrg = consumerOrg;
+    }
+
+    public String getConsumerOrg() {
+        return consumerOrg;
+    }
+
+    public Boolean getJsonOutput() {
+        return jsonOutput;
+    }
+
+    public void setJsonOutput(Boolean jsonOutput) {
+        this.jsonOutput = jsonOutput;
     }
 
     public X509Certificate getCertificate() {
@@ -83,13 +99,14 @@ public class Configuration {
     public static Configuration load(String[] args) throws Exception {
         Configuration config = new Configuration();
 
-        if (args != null && args.length == 1 && args[0] != null) {
+        if (args != null && args.length >= 1 && args[0] != null) {
 
             Properties props = readPropertyFile(args[0]);
 
             config.setIss(props.getProperty("issuer"));
             config.setAud(props.getProperty("audience"));
             config.setResource(props.getProperty("resource"));
+            config.setConsumerOrg(props.getProperty("consumer_org"));
             config.setScope(props.getProperty("scope"));
             config.setTokenEndpoint(props.getProperty("token.endpoint"));
 
@@ -99,6 +116,9 @@ public class Configuration {
             String keystoreAliasPassword = props.getProperty("keystore.alias.password");
 
             loadCertificateAndKeyFromFile(config, keystoreFile, keystorePassword, keystoreAlias, keystoreAliasPassword);
+            if (args.length == 2 && args[1].equals("json")) {
+                config.setJsonOutput(true);
+            }
 
         } else {
             System.out.println("Usaga: java -jar jwtgrant.jar <property file name>");

--- a/src/main/java/no/difi/oauth2/utils/JwtGrantGenerator.java
+++ b/src/main/java/no/difi/oauth2/utils/JwtGrantGenerator.java
@@ -1,20 +1,22 @@
 package no.difi.oauth2.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
-
-import java.time.Clock;
-import java.util.*;
-
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.util.Base64;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-import org.apache.hc.client5.http.fluent.Content;
 import org.apache.hc.client5.http.fluent.Form;
 import org.apache.hc.client5.http.fluent.Request;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.fluent.Response;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import java.time.Clock;
+import java.util.*;
 
 public class JwtGrantGenerator {
 
@@ -75,14 +77,18 @@ public class JwtGrantGenerator {
                 .add("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
                 .add("assertion", jwt)
                 .build();
-
-        Content response = Request.Post(config.getTokenEndpoint())
+        try {
+            Response response = Request.Post(config.getTokenEndpoint())
                 .bodyForm(body)
-                .execute()
-                .returnContent();
+                .execute();
 
-        return response.asString();
+            HttpEntity e = ((CloseableHttpResponse) response.returnResponse()).getEntity();
+            return EntityUtils.toString(e);
 
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
 }

--- a/src/main/java/no/difi/oauth2/utils/JwtGrantGenerator.java
+++ b/src/main/java/no/difi/oauth2/utils/JwtGrantGenerator.java
@@ -28,7 +28,7 @@ public class JwtGrantGenerator {
             Map<String, Object> output = new HashMap<>();
             output.put("grant", jwt);
             if (config.hasTokenEndpoint()) {
-                output.put("output", mapper.readValue(makeTokenRequest(jwt, config), Object.class));
+                output.put("token", mapper.readValue(makeTokenRequest(jwt, config), Object.class));
             }
             System.out.println(mapper.writeValueAsString(output));
         } else {


### PR DESCRIPTION
Will add the following changes:
1. Ability to create consumer_org claim in the grants that are generated.
2. If adding the optional second parameter "json", the output will be a single line json formatted string that can be easily parsed in scripts.
3. Added some error handling for the request to generate tokens, in order to output the error response on failures.