### PR TITLE
Consumer claim and optional output as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It is important to understand the authorization flow used for these apis, see ht
 Note: The access token is only retrieved if an token.endpoint property is given. Without this a jwt bearer grant will only be printed.
 
 ### Client configuration
-To generate a jwt-grant you need a propery file holding your client configuration:
+To generate a jwt-grant you need a property file holding your client configuration:
 
 ```
 issuer=<Your client_id>
@@ -30,6 +30,11 @@ To also retrieve an access-token from an authorization server, add this property
 token.endpoint=<Token endpoint to use, i.e. in ver2 env: https://oidc-ver2.difi.no/idporten-oidc-provider/token>
 ```
 
+If you want to generate a token utilising the delegation capabilities in Maskinporten, add this property to the properties file:
+```
+consumer_org=<the orgnumber of the consumer that has delegated the access>
+```
+
 ## Usage
 
 To build and run use:
@@ -38,5 +43,29 @@ To build and run use:
 mvn package
 
 java -jar target\jwt-grant-generator-1.0-SNAPSHOT-jar-with-dependencies.jar myclient.properties
+
+```
+
+### Output as JSON
+If you want the response as json, you can add an additional parameter so the command to build and run is
+```
+mvn package
+
+java -jar target\jwt-grant-generator-1.0-SNAPSHOT-jar-with-dependencies.jar myclient.properties json
+
+```
+
+The JSON will be a single line so it is easy to capture in a script and can then be parsed with tools like jq.
+A pretty representation of the JSON schema is
+```
+{
+    "grant": "...",
+    "token": {
+        "access_token": "...",
+        "token_type": "Bearer",
+        "expires_in": 7199,
+        "scope": "..."
+    }
+}
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,13 @@
 			<artifactId>slf4j-nop</artifactId>
 			<version>1.7.25</version>
 		</dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.0</version>
+        </dependency>
 	</dependencies>
-    
+
 	<build>
         <plugins>
             <plugin>

--- a/src/main/java/no/difi/oauth2/utils/Configuration.java
+++ b/src/main/java/no/difi/oauth2/utils/Configuration.java
@@ -1,6 +1,5 @@
 package no.difi.oauth2.utils;
 
-
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -18,7 +17,8 @@ public class Configuration {
     private String tokenEndpoint;
     private X509Certificate certificate;
     private PrivateKey privateKey;
-
+    private String consumerOrg;
+    private Boolean jsonOutput = false;
 
     public String getIss() {
         return iss;
@@ -40,8 +40,22 @@ public class Configuration {
 	return resource;
     }
 
-    public void setResource(String resource) {
-	this.resource = resource;
+    public void setResource(String resource) { this.resource = resource; }
+
+    public String getConsumerOrg() {
+        return consumerOrg;
+    }
+
+    public void setConsumerOrg(String consumerOrg) {
+	this.consumerOrg = consumerOrg;
+    }
+
+    public Boolean getJsonOutput() {
+        return jsonOutput;
+    }
+
+    public void setJsonOutput(Boolean jsonOutput) {
+        this.jsonOutput = jsonOutput;
     }
 
     public X509Certificate getCertificate() {
@@ -83,13 +97,14 @@ public class Configuration {
     public static Configuration load(String[] args) throws Exception {
         Configuration config = new Configuration();
 
-        if (args != null && args.length == 1 && args[0] != null) {
+        if (args != null && args.length >= 1 && args[0] != null) {
 
             Properties props = readPropertyFile(args[0]);
 
             config.setIss(props.getProperty("issuer"));
             config.setAud(props.getProperty("audience"));
             config.setResource(props.getProperty("resource"));
+            config.setConsumerOrg(props.getProperty("consumer_org"));
             config.setScope(props.getProperty("scope"));
             config.setTokenEndpoint(props.getProperty("token.endpoint"));
 
@@ -99,6 +114,9 @@ public class Configuration {
             String keystoreAliasPassword = props.getProperty("keystore.alias.password");
 
             loadCertificateAndKeyFromFile(config, keystoreFile, keystorePassword, keystoreAlias, keystoreAliasPassword);
+            if (args.length == 2 && args[1].equals("json")) {
+                config.setJsonOutput(true);
+            }
 
         } else {
             System.out.println("Usaga: java -jar jwtgrant.jar <property file name>");


### PR DESCRIPTION
* Ability to create consumer_org claim in the grants that are
  generated.
* If adding the optional second parameter "json", the output will be a
  single line json formatted string that can be easily parsed in scripts.
* Added some error handling for the request to generate tokens, in
  order to output the error response on failures.